### PR TITLE
Skip workflow runs from pacchettibotti comments

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -12,7 +12,9 @@ jobs:
   api:
     # This condition is here because the issue_comment event is triggered
     # for pull requests as well, but we want to ignore those.
-    if: ${{ !github.event.issue.pull_request }}
+    # The second part is so that we don't start a workflow if the author of an
+    # issue comment is pacchettibotti itself.
+    if: ${{ (!github.event.issue.pull_request) && (github.actor != 'pacchettibotti') }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The `actor` field is documented [here](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

Note: this is entirely untested 😄 