### PR TITLE
Add package purescript-halogen-bootstrap5

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -80,6 +80,7 @@
   "purescript-graphql-validator": "https://github.com/meeshkan/purescript-graphql-validator.git",
   "purescript-graphqlclient": "https://github.com/purescript-graphqlclient/purescript-graphqlclient.git",
   "purescript-grid-reactors": "https://github.com/Eugleo/purescript-grid-reactors.git",
+  "purescript-halogen-bootstrap5": "https://github.com/tonicebrian/purescript-halogen-bootstrap5.git",
   "purescript-halogen-hooks": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
   "purescript-halogen-hooks-extra": "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git",
   "purescript-halogen-router": "https://github.com/katsujukou/purescript-halogen-router.git",


### PR DESCRIPTION
This package provides typed classes for Halogen containing all classed defined in Bootstrap 5.2.2 and extracted from the CSS https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css