### PR TITLE
Add note about retrying docs for Pursuit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 The PureScript Registry stores PureScript packages (and metadata about them) and provides an API for registering, updating, transferring, and unpublishing packages. Most PureScript users will only interact with the registry via package managers.
 
-:warning: As of September 2022, no package manager officially supports the registry. To register your package, please open an issue using the [Publish](#publish-a-package) workflow. Once registered, your package will be added to the package sets automatically (if it compiles with the current package set), its docs will be uploaded to Pursuit, and any SemVer tag you publish on the repository in the future will automatically update your package in the registry.
+> **Warning**
+> As of September 2022, no package manager officially supports the registry. To register your package, please open an issue using the [Publish](#publish-a-package) workflow. Once registered, your package will be added to the package sets automatically (if it compiles with the current package set), its docs will be uploaded to Pursuit, and any SemVer tag you publish on the repository in the future will automatically update your package in the registry.
 
 ## Registry Overview
 
@@ -35,7 +36,8 @@ The Registry API allows anyone to publish a package version or upgrade the packa
 
 To publish a [new package](https://github.com/purescript/registry/issues/new?title=Add+my-library&template=publish_new.md) or to [publish a new version of an existing package](https://github.com/purescript/registry/issues/new?title=Update+my-library&template=publish_update.md), open a new issue with a comment consisting of package metadata in the JSON format shown below.
 
-> NOTE: If your package is in the registry but it is missing documentation on Pursuit, you can re-publish an existing version to re-generate documentation.
+> **Note**
+> If your package is in the registry but it is missing documentation on Pursuit, you can re-publish an existing version to re-generate documentation.
 
 ```jsonc
 // Please note that jsonc is not supported, only used here for documentation.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The Registry API allows anyone to publish a package version or upgrade the packa
 
 #### Publish a Package
 
-To publish a [new package](https://github.com/purescript/registry/issues/new?title=Add+my-library&template=publish_new.md) or an [update to an existing package](https://github.com/purescript/registry/issues/new?title=Update+my-library&template=publish_update.md) (e.g. a new version), [open a new issue](https://github.com/purescript/registry/issues/new) with a comment consisting of package metadata in the JSON format shown below.
+To publish a [new package](https://github.com/purescript/registry/issues/new?title=Add+my-library&template=publish_new.md) or to [publish a new version of an existing package](https://github.com/purescript/registry/issues/new?title=Update+my-library&template=publish_update.md), open a new issue with a comment consisting of package metadata in the JSON format shown below.
+
+> NOTE: If your package is in the registry but it is missing documentation on Pursuit, you can re-publish an existing version to re-generate documentation.
 
 ```jsonc
 // Please note that jsonc is not supported, only used here for documentation.


### PR DESCRIPTION
As per https://github.com/purescript/registry-dev/pull/604, this PR adds a note to the README that clarifies that you can republish an existing package version to get its docs onto Pursuit, if they aren't already there.